### PR TITLE
To correct errors in MMM2D code

### DIFF
--- a/build-aux/fortran-depcomp
+++ b/build-aux/fortran-depcomp
@@ -2,7 +2,7 @@
 
 FILES=$*
 
-IGNORE="${IGNORE} iso_c_binding"
+IGNORE="${IGNORE} iso_c_binding mpi"
 FORTEXT="f F f90 F90 f95 F95 f03 F03 f08 F08"
 
 UNIQSTR="QWERTZ"

--- a/lib/fmm/src/mp_wrapper.f90
+++ b/lib/fmm/src/mp_wrapper.f90
@@ -491,7 +491,12 @@ implicit none
 	integer(MyMPI_Comm) 		:: comm
 	integer(MyMPI_Errorcode)	:: ierr,ierr2
 	integer(MyMPI_Entries)		:: elem_tmp
-	
+	interface
+	  subroutine mpi_allreduce(send,recv,num,rtype,rop,rcomm,rerr)
+	    integer(kind=8)		:: recv
+	    integer(kind=4)		:: send, num, rop, rtype, rcomm, rerr
+	  end subroutine mpi_allreduce
+	end interface
 		elem_tmp = 1
 		
 		call mpi_allreduce(MPI_IN_PLACE,dst,elem_tmp,MPI_INTEGER8,op,comm,ierr)
@@ -510,6 +515,12 @@ implicit none
 	integer(MyMPI_Comm) 		:: comm
 	integer(MyMPI_Errorcode)	:: ierr,ierr2
 	integer(MyMPI_Entries)		:: elem_tmp
+	interface
+	  subroutine mpi_allreduce(send,recv,num,rtype,rop,rcomm,rerr)
+	    integer(kind=8), dimension(*) :: recv
+	    integer(kind=4)		:: send, num, rop, rtype, rcomm, rerr
+	  end subroutine mpi_allreduce
+	end interface
 	
 		elem_tmp = elem
 		
@@ -528,6 +539,12 @@ implicit none
 	integer(MyMPI_Comm) 	:: comm
 	integer(MyMPI_Errorcode):: ierr,ierr2
 	integer(MyMPI_Entries)	:: elem_tmp
+	interface
+	  subroutine mpi_allreduce(send,recv,num,rtype,rop,rcomm,rerr)
+	    real(kind=4)		:: recv
+	    integer(kind=4)		:: send, num, rop, rtype, rcomm, rerr
+	  end subroutine mpi_allreduce
+	end interface
 	
 		elem_tmp = 1
 		
@@ -547,6 +564,12 @@ implicit none
 	integer(MyMPI_Comm) 		:: comm
 	integer(MyMPI_Errorcode)	:: ierr,ierr2
 	integer(MyMPI_Entries)		:: elem_tmp
+	interface
+	  subroutine mpi_allreduce(send,recv,num,rtype,rop,rcomm,rerr)
+	    real(kind=4), dimension(*)	:: recv
+	    integer(kind=4)		:: send, num, rop, rtype, rcomm, rerr
+	  end subroutine mpi_allreduce
+	end interface
 	
 		elem_tmp = elem
 		
@@ -566,6 +589,12 @@ implicit none
         integer(MyMPI_Comm)             :: comm
         integer(MyMPI_Errorcode)        :: ierr,ierr2
         integer(MyMPI_Entries)          :: elem_tmp
+	interface
+	  subroutine mpi_allreduce(send,recv,num,rtype,rop,rcomm,rerr)
+	    real(kind=4), dimension(*)	:: recv
+	    integer(kind=4)		:: send, num, rop, rtype, rcomm, rerr
+	  end subroutine mpi_allreduce
+	end interface
         
                 lo = lbound(dst,1)
                 hi = ubound(dst,1)
@@ -586,6 +615,12 @@ implicit none
 	integer(MyMPI_Comm) 	:: comm
 	integer(MyMPI_Errorcode):: ierr,ierr2
 	integer(MyMPI_Entries)	:: elem_tmp
+	interface
+	  subroutine mpi_allreduce(send,recv,num,rtype,rop,rcomm,rerr)
+	    real(kind=8)		:: recv
+	    integer(kind=4)		:: send, num, rop, rtype, rcomm, rerr
+	  end subroutine mpi_allreduce
+	end interface
 	
 		elem_tmp = 1
 		
@@ -605,6 +640,12 @@ implicit none
 	integer(MyMPI_Comm) 		:: comm
 	integer(MyMPI_Errorcode)	:: ierr,ierr2
 	integer(MyMPI_Entries)		:: elem_tmp
+	interface
+	  subroutine mpi_allreduce(send,recv,num,rtype,rop,rcomm,rerr)
+	    real(kind=8), dimension(*)	:: recv
+	    integer(kind=4)		:: send, num, rop, rtype, rcomm, rerr
+	  end subroutine mpi_allreduce
+	end interface
 	
 		elem_tmp = elem
 		
@@ -624,6 +665,12 @@ implicit none
 	integer(MyMPI_Comm) 		:: comm
 	integer(MyMPI_Errorcode)	:: ierr,ierr2
 	integer(MyMPI_Entries)		:: elem_tmp
+	interface
+	  subroutine mpi_allreduce(send,recv,num,rtype,rop,rcomm,rerr)
+	    real(kind=8), dimension(*)	:: recv
+	    integer(kind=4)		:: send, num, rop, rtype, rcomm, rerr
+	  end subroutine mpi_allreduce
+	end interface
 	
 		lo = lbound(dst,1)
 		hi = ubound(dst,1)
@@ -648,6 +695,12 @@ implicit none
 	integer(MyMPI_Comm) 	:: comm
 	integer(MyMPI_Errorcode):: ierr,ierr2
 	integer(MyMPI_Entries)	:: elem_tmp
+	interface
+	  subroutine mpi_allgather(send,snum,stype,recv,rnum,rtype,gcomm,gerr)
+	    byte, dimension(*)	:: recv
+	    integer(kind=4)		:: send, snum, rnum, stype, rtype, gcomm, gerr
+	  end subroutine mpi_allgather
+	end interface
 	
 		lo = lbound(dst,1)
 		hi = ubound(dst,1)	
@@ -668,6 +721,12 @@ implicit none
 	integer(MyMPI_Comm) 	:: comm
 	integer(MyMPI_Errorcode):: ierr,ierr2
 	integer(MyMPI_Entries)	:: elem_tmp
+	interface
+	  subroutine mpi_allgather(send,snum,stype,recv,rnum,rtype,gcomm,gerr)
+	    byte, dimension(*)	:: recv
+	    integer(kind=4)		:: send, snum, rnum, stype, rtype, gcomm, gerr
+	  end subroutine mpi_allgather
+	end interface
 	
 		lo1 = lbound(dst,1)
 		hi1 = ubound(dst,1)
@@ -690,6 +749,12 @@ implicit none
 	integer(MyMPI_Comm) 		:: comm
 	integer(MyMPI_Errorcode)	:: ierr,ierr2
 	integer(MyMPI_Entries)		:: elem_tmp
+	interface
+	  subroutine mpi_allgather(send,snum,stype,recv,rnum,rtype,gcomm,gerr)
+	    real(kind=4), dimension(*)	:: recv
+	    integer(kind=4)		:: send, snum, rnum, stype, rtype, gcomm, gerr
+	  end subroutine mpi_allgather
+	end interface
 	
 		elem_tmp = elem
 		
@@ -708,6 +773,12 @@ implicit none
 	integer(MyMPI_Comm) 		:: comm
 	integer(MyMPI_Errorcode)	:: ierr,ierr2
 	integer(MyMPI_Entries)		:: elem_tmp
+	interface
+	  subroutine mpi_allgather(send,snum,stype,recv,rnum,rtype,gcomm,gerr)
+	    integer(kind=8), dimension(*)	:: recv
+	    integer(kind=4)		:: send, snum, rnum, stype, rtype, gcomm, gerr
+	  end subroutine mpi_allgather
+	end interface
 	
 		elem_tmp = elem
 		
@@ -726,6 +797,12 @@ implicit none
 	integer(MyMPI_Comm) 		:: comm
 	integer(MyMPI_Errorcode)	:: ierr,ierr2
 	integer(MyMPI_Entries)		:: elem_tmp
+	interface
+	  subroutine mpi_allgather(send,snum,stype,recv,rnum,rtype,gcomm,gerr)
+	    integer(kind=8), dimension(*)	:: recv
+	    integer(kind=4)		:: send, snum, rnum, stype, rtype, gcomm, gerr
+	  end subroutine mpi_allgather
+	end interface
 	
 		lo = lbound(dst,1)
 		hi = ubound(dst,1)	

--- a/lib/memd/communication.c
+++ b/lib/memd/communication.c
@@ -395,11 +395,11 @@ void fcs_memd_exchange_surface_patch(memd_struct* memd, fcs_float *field, fcs_in
         MPI_Type_commit(&yzPlane2D);
 		
         /* create data type for xz plaquette */
-        MPI_Type_hvector(2,1*sizeof(fcs_float),2*sizeof(fcs_float), MPI_BYTE, &xz_plaq);
+        MPI_Type_create_hvector(2,1*sizeof(fcs_float),2*sizeof(fcs_float), MPI_BYTE, &xz_plaq);
         /* create data type for a 1D section */
         MPI_Type_contiguous(surface_patch[2].stride, xz_plaq, &oneslice); 
         /* create data type for a 2D xz plane */
-        MPI_Type_hvector(surface_patch[2].nblocks, 1, dim*surface_patch[2].skip*sizeof(fcs_float), oneslice, &xzPlane2D);
+        MPI_Type_create_hvector(surface_patch[2].nblocks, 1, dim*surface_patch[2].skip*sizeof(fcs_float), oneslice, &xzPlane2D);
         MPI_Type_commit(&xzPlane2D);    
         /* create data type for a 2D xy plane */
         MPI_Type_vector(surface_patch[4].nblocks, 2, dim*surface_patch[4].skip, FCS_MPI_FLOAT, &xyPlane2D);

--- a/lib/pepc/src/module_box.f90
+++ b/lib/pepc/src/module_box.f90
@@ -48,8 +48,8 @@ module module_box
     use module_comm_env, only: t_comm_env
     use module_pepc_types
     use module_debug
+    use mpi
     implicit none
-    include 'mpif.h'
 
     type(t_box), intent(out) :: b !< the bounding box that contains all `p`
     type(t_particle), intent(in) :: p(:) !< particles to embed in the bounding box

--- a/lib/pepc/src/module_comm_env.f90
+++ b/lib/pepc/src/module_comm_env.f90
@@ -61,8 +61,8 @@ module module_comm_env
   !> process.
   !>
   subroutine comm_env_mirror_from_mpi(comm, c)
+    use mpi
     implicit none
-    include 'mpif.h'
 
     integer, intent(in) :: comm !< the MPI communicator used for communication
     type(t_comm_env), intent(out) :: c !< the communication environment to initialize
@@ -128,8 +128,8 @@ module module_comm_env
   !> Calls `mpi_comm_free` on the MPI communicator contained in `c`.
   !>
   subroutine comm_env_destroy(c)
+    use mpi
     implicit none
-    include 'mpif.h'
 
     type(t_comm_env), intent(inout) :: c !< environment to destroy
     integer(kind_default) :: ierr

--- a/lib/pepc/src/module_debug.f90
+++ b/lib/pepc/src/module_debug.f90
@@ -41,18 +41,18 @@ module module_debug
       !             db_level = 5      --> debug_level = 128
       !             db_level = 6      --> debug_level = 1 + 2 + 32 + 64 + 8 + 2048 + 4 + 16 + 128 + 256 + 512 = 3071
       !
-      integer, parameter, public :: DBG_STATUS      = B'0000000000000001'    ! 1
-      integer, parameter, public :: DBG_TREE        = B'0000000000000010'    ! 2
-      integer, parameter, public :: DBG_BUILD       = B'0000000000000100'    ! 4
-      integer, parameter, public :: DBG_DOMAIN      = B'0000000000001000'    ! 8
-      integer, parameter, public :: DBG_BRANCH      = B'0000000000010000'    ! 16
-      integer, parameter, public :: DBG_STATS       = B'0000000000100000'    ! 32
-      integer, parameter, public :: DBG_WALKSUMMARY = B'0000000001000000'    ! 64
-      integer, parameter, public :: DBG_DUMPTREE    = B'0000000010000000'    ! 128
-      integer, parameter, public :: DBG_TIMINGFILE  = B'0000000100000000'    ! 256
-      ! deprecated: integer, parameter, public :: DBG_LOADFILE    = B'0000001000000000'    ! 512
-      integer, parameter, public :: DBG_WALK        = B'0000010000000000'    ! 1024
-      integer, parameter, public :: DBG_PERIODIC    = B'0000100000000000'    ! 2048
+      integer, parameter, public :: DBG_STATUS      = int(B'0000000000000001')    ! 1
+      integer, parameter, public :: DBG_TREE        = int(B'0000000000000010')    ! 2
+      integer, parameter, public :: DBG_BUILD       = int(B'0000000000000100')    ! 4
+      integer, parameter, public :: DBG_DOMAIN      = int(B'0000000000001000')    ! 8
+      integer, parameter, public :: DBG_BRANCH      = int(B'0000000000010000')    ! 16
+      integer, parameter, public :: DBG_STATS       = int(B'0000000000100000')    ! 32
+      integer, parameter, public :: DBG_WALKSUMMARY = int(B'0000000001000000')    ! 64
+      integer, parameter, public :: DBG_DUMPTREE    = int(B'0000000010000000')    ! 128
+      integer, parameter, public :: DBG_TIMINGFILE  = int(B'0000000100000000')    ! 256
+      ! deprecated: integer, parameter, public :: DBG_LOADFILE    = int(B'0000001000000000')    ! 512
+      integer, parameter, public :: DBG_WALK        = int(B'0000010000000000')    ! 1024
+      integer, parameter, public :: DBG_PERIODIC    = int(B'0000100000000000')    ! 2048
 
       logical, private       :: debug_initialized = .false.
       character(30), private :: debug_ipefile_name
@@ -98,8 +98,8 @@ module module_debug
      subroutine debug_initialize()
        use treevars
        use module_utils, only: create_directory
+       use mpi
        implicit none
-       include 'mpif.h'
 
        character(MPI_MAX_PROCESSOR_NAME) :: procname
        integer(kind_default) :: resultlen, ierr
@@ -180,11 +180,11 @@ module module_debug
      !>
      subroutine debug_mpi_abort()
        use treevars, only : MPI_COMM_lpepc
+       use mpi
        #if defined(__ICC) || defined(__INTEL_COMPILER)
          use ifcore
        #endif
        implicit none
-       include 'mpif.h'
        integer(kind_default) :: ierr
 
        ! starting from GCC version 4.8, a backtrace() subroutine is provided by gfortran
@@ -213,8 +213,8 @@ module module_debug
      !>
      subroutine debug_barrier()
        use treevars, only : MPI_COMM_lpepc
+       use mpi
        implicit none
-       include 'mpif.h'
        integer(kind_default) :: ierr
 
        call MPI_BARRIER(MPI_COMM_lpepc, ierr)

--- a/lib/pepc/src/module_domains.f90
+++ b/lib/pepc/src/module_domains.f90
@@ -117,8 +117,8 @@ module module_domains
     use module_timings
     use module_spacefilling, only: key_to_coord
     use module_debug
+    use mpi
     implicit none
-    include 'mpif.h'
 
     type(t_decomposition), intent(inout) :: d
     type(t_box), intent(in) :: b
@@ -333,8 +333,8 @@ module module_domains
     !>   bp(2) = particles[me + 1](1)
     !>
     subroutine exchange_boundary_particles()
+      use mpi
       implicit none
-      include 'mpif.h'
 
       integer :: state(MPI_STATUS_SIZE)
       integer(kind_particle) :: npp
@@ -377,8 +377,8 @@ module module_domains
   subroutine domain_restore(d, p)
       use module_pepc_types, only: t_particle, mpi_type_particle
       use module_debug, only : pepc_status
+      use mpi
       implicit none
-      include 'mpif.h'
 
       type(t_decomposition), intent(inout) :: d
       type(t_particle), intent(inout), allocatable :: p(:)

--- a/lib/pepc/src/module_fmm_framework.f90
+++ b/lib/pepc/src/module_fmm_framework.f90
@@ -27,8 +27,8 @@ module module_fmm_framework
       use module_debug
       use module_mirror_boxes
       use module_interaction_specific_types, only : t_tree_node_interaction_data
+      use mpi
       implicit none
-      include 'mpif.h'
       private
 
       ! TODO: set dipole- and low-order stuff in MLattice to zero

--- a/lib/pepc/src/module_interaction_specific_types_XYZQ.f90
+++ b/lib/pepc/src/module_interaction_specific_types_XYZQ.f90
@@ -94,8 +94,8 @@ module module_interaction_specific_types
       !> is automatically called from register_libpepc_mpi_types()
       !>
       subroutine register_interaction_specific_mpi_types(mpi_type_particle_data, MPI_TYPE_tree_node_interaction_data, mpi_type_particle_results)
+        use mpi
         implicit none
-        include 'mpif.h'
         integer, intent(out) :: mpi_type_particle_data, MPI_TYPE_tree_node_interaction_data, mpi_type_particle_results
 
         integer, parameter :: max_props = nprops_particle_data + nprops_particle_results + nprops_tree_node_interaction_data ! maxval([..]) would be enough, but ifort does notlike that

--- a/lib/pepc/src/module_math_tools.f90
+++ b/lib/pepc/src/module_math_tools.f90
@@ -182,8 +182,8 @@ module module_math_tools
           use treevars, only: idim
           use module_spacefilling
           use module_debug
+          use mpi
           implicit none
-          include 'mpif.h'
 
           integer(kind_key), intent(in) :: a, b
           integer(kind_key) :: bpi

--- a/lib/pepc/src/module_pepc.f90
+++ b/lib/pepc/src/module_pepc.f90
@@ -74,8 +74,8 @@ module module_pepc
       use module_domains
       use module_debug
       use pthreads_stuff, only: get_my_core
+      use mpi
       implicit none
-      include 'mpif.h'
       character(*), intent(in) :: frontendname !< name of the program that uses the treecode (only for output purposes)
       integer(kind_pe), optional, intent(out) :: my_rank !< MPI rank of this instance as returned from MPI
       integer(kind_pe), optional, intent(out) :: n_cpu !< number of MPI ranks as returned from MPI
@@ -304,8 +304,8 @@ module module_pepc
       use treevars, only : treevars_finalize, MPI_COMM_lpepc
       use pthreads_stuff, only: pthreads_uninit
       use module_tree_communicator, only: tree_communicator_finalize
+      use mpi
       implicit none
-      include 'mpif.h'
       integer(kind_default) :: ierr
 
       integer, intent(inout), optional :: comm !< communicator. if pepc_initialize() initializes MPI, it returns an MPI_COMM_DUP-copy of its own communicator in comm, that can be given here to be freed automatically
@@ -337,8 +337,8 @@ module module_pepc
     !>
     subroutine pepc_get_para_file(available, file_name, my_rank, comm)
         use treevars, only : MPI_COMM_lpepc
+        use mpi
         implicit none
-        include 'mpif.h'
 
         logical, intent(out)          :: available
         character(len=255), intent(out) :: file_name

--- a/lib/pepc/src/module_pepc_types.f90
+++ b/lib/pepc/src/module_pepc_types.f90
@@ -23,11 +23,10 @@
 !>
 module module_pepc_types
   use module_interaction_specific_types
+  use mpi
   implicit none
   
   private
-
-  include 'mpif.h'
 
   public :: t_particle_data
   public :: t_particle_results
@@ -119,9 +118,9 @@ module module_pepc_types
       !> Creates and registers lpepc-MPI types
       !>
       subroutine register_lpepc_mpi_types()
+        use mpi
         use module_interaction_specific_types
         implicit none
-        include 'mpif.h'
 
         integer, parameter :: max_props = nprops_particle + nprops_tree_node_package + nprops_request_eager
 
@@ -190,8 +189,8 @@ module module_pepc_types
       !> Deregisters lpepc- and interaction-specific MPI types
       !>
       subroutine free_lpepc_mpi_types()
+        use mpi
         implicit none
-        include 'mpif.h'
         integer(kind_default) :: ierr
 
         call MPI_TYPE_FREE( MPI_TYPE_tree_node_package,            ierr)

--- a/lib/pepc/src/module_timings.f90
+++ b/lib/pepc/src/module_timings.f90
@@ -216,8 +216,8 @@ module module_timings
     !>      tim(id) = - MPI_WTIME()
     !>
     subroutine timer_start(id)
+      use mpi
       implicit none
-      include 'mpif.h'
       integer, intent(in) :: id !< the affected timer address
 
       tim(id) = - MPI_WTIME()
@@ -230,8 +230,8 @@ module module_timings
     !>      tim(id) = tim(id) + MPI_WTIME()
     !>
     subroutine timer_stop(id)
+      use mpi
       implicit none
-      include 'mpif.h'
       integer, intent(in) :: id !< the affected timer address
 
       tim(id) = tim(id) + MPI_WTIME()
@@ -259,8 +259,8 @@ module module_timings
     !>      accumulated_time = timer_read(t_example)
     !>
     subroutine timer_resume(id)
+      use mpi
       implicit none
-      include 'mpif.h'
       integer, intent(in) :: id !< the affected timer address
 
       tim(id) = tim(id) - MPI_WTIME()
@@ -352,8 +352,8 @@ module module_timings
       use treevars
       use module_utils, only: create_directory
       use module_pepc_types
+      use mpi
       implicit none
-      include 'mpif.h'
       integer, intent(in) :: itime !< current timestep
       integer, optional, intent(in) :: iuserflag !< frontend-defined flag that is passed through and output to the second column
       logical, optional, intent(in) :: printheader

--- a/lib/pepc/src/module_tree.f90
+++ b/lib/pepc/src/module_tree.f90
@@ -660,8 +660,8 @@ module module_tree
     subroutine tree_stats(t, u)
       use treevars, only: np_mult
       use module_debug
+      use mpi
       implicit none
-      include 'mpif.h'
 
       type(t_tree), intent(in) :: t
       integer, intent(in) :: u

--- a/lib/pepc/src/module_tree_communicator.f90
+++ b/lib/pepc/src/module_tree_communicator.f90
@@ -93,8 +93,8 @@ module module_tree_communicator
   subroutine tree_communicator_prepare()
     use treevars, only: mpi_comm_lpepc
     use module_pepc_types, only: mpi_type_tree_node_package
+    use mpi
     implicit none
-    include 'mpif.h'
 
     integer(kind_default) :: msg_size_request, msg_size_data, buffsize, ierr
 
@@ -119,8 +119,8 @@ module module_tree_communicator
   !> Deallocate MPI communication buffers in pepc_finalize.
   !>
   subroutine tree_communicator_finalize()
+    use mpi
     implicit none
-    include 'mpif.h'
 
     integer(kind_default) :: dummy, buffsize, ierr
 
@@ -192,8 +192,8 @@ module module_tree_communicator
     use module_atomic_ops, only: atomic_load_int, atomic_store_int
     use module_debug
     use module_timings
+    use mpi
     implicit none
-    include 'mpif.h'
 
     type(t_tree), intent(inout) :: t
 
@@ -239,8 +239,8 @@ module module_tree_communicator
       atomic_write_barrier, atomic_load_int
     use module_tree_node
     use module_debug
+    use mpi
     implicit none
-    include 'mpif.h'
 
     type(t_tree), intent(inout) :: t
     type(t_tree_node), target, intent(inout) :: n
@@ -300,8 +300,8 @@ module module_tree_communicator
   subroutine broadcast_comm_finished(t)
     use module_tree, only: t_tree
     use module_debug
+    use mpi
     implicit none
-    include 'mpif.h'
 
     type(t_tree), intent(in) :: t
     integer(kind_pe) :: i
@@ -327,8 +327,8 @@ module module_tree_communicator
   subroutine broadcast_dump_tree_and_abort(t)
     use module_tree, only: t_tree
     use module_debug
+    use mpi
     implicit none
-    include 'mpif.h'
 
     type(t_tree), intent(in) :: t
     integer(kind_pe) :: i
@@ -375,8 +375,8 @@ module module_tree_communicator
   subroutine send_data(t, nodes, numnodes, adressee)
     use module_tree, only: t_tree
     use module_pepc_types, only: t_tree_node, t_tree_node_package, MPI_TYPE_tree_node_package, t_request_eager
+    use mpi
     implicit none
-    include 'mpif.h'
 
     type(t_tree), intent(inout) :: t
     type(t_tree_node_package), contiguous, intent(in) :: nodes(:)
@@ -543,8 +543,8 @@ module module_tree_communicator
     use module_spacefilling, only: parent_key_from_key
     use module_atomic_ops, only: atomic_write_barrier
     use module_debug
+    use mpi
     implicit none
-    include 'mpif.h'
 
     type(t_tree), intent(inout) :: t
     type(t_tree_node_package) :: child_data(num_children) !< child data that has been received
@@ -644,8 +644,8 @@ module module_tree_communicator
     use module_comm_env, only: t_comm_env
     use module_atomic_ops, only: t_atomic_int, atomic_load_int, atomic_store_int, atomic_read_barrier
     use module_debug
+    use mpi
     implicit none
-    include 'mpif.h'
 
     type(t_request_queue_entry), volatile, intent(inout) :: q(TREE_COMM_REQUEST_QUEUE_LENGTH) !< request queue
     type(t_atomic_int), intent(inout) :: b !< queue bottom
@@ -689,8 +689,8 @@ module module_tree_communicator
     function send_request(req, comm_env)
       use module_tree_node
       use module_pepc_types, only : MPI_TYPE_request_eager
+      use mpi
       implicit none
-      include 'mpif.h'
 
       logical :: send_request
       type(t_request_queue_entry), volatile, intent(inout) :: req
@@ -737,8 +737,8 @@ module module_tree_communicator
     use pthreads_stuff, only: pthreads_sched_yield, get_my_core, pthreads_exitthread
     use module_atomic_ops, only: atomic_load_int, atomic_store_int, atomic_write_barrier
     use module_debug
+    use mpi
     implicit none
-    include 'mpif.h'
 
     type(c_ptr) :: run_communication_loop
     type(c_ptr), value :: arg
@@ -827,9 +827,9 @@ module module_tree_communicator
     use module_tree, only: t_tree
     use module_pepc_types, only: t_tree_node_package, MPI_TYPE_tree_node_package, t_request_eager, MPI_TYPE_request_eager
     use module_atomic_ops, only: atomic_store_int
+    use mpi
     use module_debug
     implicit none
-    include 'mpif.h'
 
     type(t_tree), intent(inout) :: t
     logical, intent(inout) :: comm_finished(:)

--- a/lib/pepc/src/module_tree_grow.f90
+++ b/lib/pepc/src/module_tree_grow.f90
@@ -45,8 +45,8 @@ module module_tree_grow
     use module_box, only: box_create
     use treevars, only: MPI_COMM_lpepc
     use module_spacefilling, only: compute_particle_keys
+    use mpi
     implicit none
-    include 'mpif.h'
 
     type(t_tree), intent(inout) :: t !< the tree
     type(t_particle), allocatable, intent(inout) :: p(:) !< input particle data, initializes %x, %data, %work appropriately (and optionally set %label) before calling this function
@@ -151,8 +151,8 @@ module module_tree_grow
     use module_debug, only : pepc_status
     use module_timings
     use module_debug
+    use mpi
     implicit none
-    include 'mpif.h'
 
     type(t_tree), intent(inout) :: t !< the tree
     integer(kind_node), intent(in) :: num_local_branch_nodes !< number of local branch nodes (valid entries in local_branch_nodes(1:num_local_branch_nodes), everything beyond is garbage

--- a/lib/pepc/src/module_utils.f90
+++ b/lib/pepc/src/module_utils.f90
@@ -60,8 +60,8 @@ module module_utils
 
   !> checks if MPI_IN_PLACE might be damaged and aborts the application if necessary
   subroutine MPI_IN_PLACE_test(comm)
+    use mpi
     implicit none
-    include 'mpif.h'
 
     integer, intent(inout) :: comm
 

--- a/lib/pepc/src/module_vtk.f90
+++ b/lib/pepc/src/module_vtk.f90
@@ -169,8 +169,8 @@ module module_vtk
 
       subroutine vtkfile_create_parallel(vtk, filename_, step_, my_rank_, num_pe_, simtime_, vtk_step_, comm_)
         use module_utils
+        use mpi
         implicit none
-        include 'mpif.h'
         class(vtkfile) :: vtk
         character(*) :: filename_
         character(50) :: fn
@@ -960,8 +960,8 @@ module module_vtk
 
 
      subroutine vtkfile_rectilinear_grid_write_final(vtk)
+        use mpi
         implicit none
-        include 'mpif.h'
         class(vtkfile_rectilinear_grid) :: vtk
         integer :: i
         character(6) :: tmp

--- a/lib/pepc/src/module_walk_pthreads.f90
+++ b/lib/pepc/src/module_walk_pthreads.f90
@@ -146,8 +146,8 @@ module module_walk
   !>
   subroutine tree_walk_statistics(u)
     use treevars, only: me, num_pe, MPI_COMM_lpepc
+    use mpi
     implicit none
-    include 'mpif.h'
 
     integer, intent(in) :: u
 
@@ -254,8 +254,8 @@ module module_walk
     use module_pepc_types
     use module_timings
     use module_debug
+    use mpi
     implicit none
-    include 'mpif.h'
 
     real*8, intent(in) :: vbox_(3) !< real space shift vector of box to be processed
 
@@ -358,8 +358,8 @@ module module_walk
     use module_atomic_ops
     use module_pepc_types
     use treevars, only: main_thread_processor_id
+    use mpi
     implicit none
-    include 'mpif.h'
 
     type(c_ptr) :: walk_worker_thread
     type(c_ptr), value :: arg
@@ -573,8 +573,8 @@ module module_walk
     #endif
     use module_atomic_ops
     use module_pepc_types
+    use mpi
     implicit none
-    include 'mpif.h'
 
     type(t_particle), intent(inout) :: particle
     integer(kind_node), dimension(:), pointer, intent(in) :: defer_list_old

--- a/lib/pp3mg/pp3mg/particle.c
+++ b/lib/pp3mg/pp3mg/particle.c
@@ -100,7 +100,7 @@ void update_particle_ghosts( int** ll_addr, int*** hoc, pp3mg_particle** particl
   mpi_blockcounts[0] = 8;
   mpi_offsets[0] = 0;
   mpi_oldtypes[0] = MPI_DOUBLE;
-  MPI_Type_struct( 1, mpi_blockcounts, mpi_offsets, mpi_oldtypes, &mpi_type_particle );
+  MPI_Type_create_struct( 1, mpi_blockcounts, mpi_offsets, mpi_oldtypes, &mpi_type_particle );
   MPI_Type_commit( &mpi_type_particle );
   
   particles = *particles_addr;

--- a/src/fcs_fmm.c
+++ b/src/fcs_fmm.c
@@ -430,7 +430,7 @@ FCSResult fcs_fmm_tune(FCS handle, fcs_int local_particles, fcs_float *positions
   return FCS_RESULT_SUCCESS;
 }
 
-int fcs_mpi_fmm_sort_front_part, fcs_mpi_fmm_sort_back_part, fcs_mpi_fmm_sort_front_merge_presorted;
+extern int fcs_mpi_fmm_sort_front_part, fcs_mpi_fmm_sort_back_part, fcs_mpi_fmm_sort_front_merge_presorted;
 
 /* internal fmm-specific run function */
 FCSResult fcs_fmm_run(FCS handle, fcs_int local_particles,


### PR DESCRIPTION
This change is to patch key errors in energy calculations using MMM2D method.
Changes were made for the parts of near force, far force and layer contributions, respectively.

The paper of "Compu. Phys. Commu. 148, 2002, 327-348" and MMM2D code in ESPResSoMD were taken as references.